### PR TITLE
Rewrite origin path to openapi path

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ async function koa2OA3 (app, apiSpecOrUri, {
   docsHideTopbar = true,
   docsAuthOptions = {},
   docDdefaultModelRendering = 'schema',
+  rewrite = p => p,
   handleError = ({ code, location, message }) => {
     return {
       errors: [{

--- a/index.js
+++ b/index.js
@@ -99,6 +99,6 @@ async function koa2OA3 (app, apiSpecOrUri, {
 
   // apply request validation
   app.use(oas(apiSpec, {
-    handleError
+    handleError, rewrite,
   }));
 }

--- a/src/oas.js
+++ b/src/oas.js
@@ -6,13 +6,14 @@ const {
 } = require('oas3-chow-chow');
 
 exports.oas = function oas (apiSpec, {
-  handleError
+  handleError,
+  rewrite = p => p,
 }) {
   const compiled = new ChowChow(apiSpec);
 
   return async (ctx, next) => {
     try {
-      compiled.validateRequest(ctx.path, {
+      compiled.validateRequest(rewrite(ctx.path), {
         method: ctx.request.method,
         header: ctx.request.header,
         query: ctx.request.query,


### PR DESCRIPTION
A application that include openapi and non-openapi, for example:
```
router.get('/openapi/:table', ...)

router.get('/otherapi/abc', ...)
```
the pull request is for rewrite the origin request path to the openapi definition path